### PR TITLE
Move Tidelift content out of the sidebar

### DIFF
--- a/docs/_templates/tidelift-sidebar.html
+++ b/docs/_templates/tidelift-sidebar.html
@@ -1,6 +1,0 @@
-<h3 class="donation">For Enterprise</h3>
-
-<p>
-Professionally-supported {{ project }} is available with the
-<a href="https://tidelift.com/subscription/pkg/pypi-{{ project }}?utm_source=pypi-{{ project }}&utm_medium=referral">Tidelift Subscription</a>.
-</p>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,0 @@
-
-# Custom sidebar templates, maps document names to template names.
-html_theme = 'alabaster'
-templates_path = ['_templates']
-html_sidebars = {'index': ['tidelift-sidebar.html']}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 .. toctree::
-   For Enterprise <https://tidelift.com/subscription/pkg/pypi-{{ project }}?utm_source=pypi-{{ project }}&utm_medium=referral&utm_campaign=docs>
+   For Enterprise <https://tidelift.com/subscription/pkg/pypi-PROJECT?utm_source=pypi-PROJECT&utm_medium=referral&utm_campaign=docs>
 
 
 For Enterprise
@@ -13,23 +13,23 @@ For Enterprise
    :widths: 10 100
 
    * - |tideliftlogo|_
-     - Professional support for {{ project }} is available as part of the `Tidelift
+     - Professional support for |project| is available as part of the `Tidelift
        Subscription`_.  Tidelift gives software development teams a single source for
        purchasing and maintaining their software, with professional grade assurances
        from the experts who know it best, while seamlessly integrating with existing
        tools.
 
-.. _Tidelift Subscription: https://tidelift.com/subscription/pkg/pypi-{{ project }}?utm_source=pypi-{{ project }}&utm_medium=referral&utm_campaign=docs
-.. _tideliftlogo: https://tidelift.com/subscription/pkg/pypi-{{ project }}?utm_source=pypi-{{ project }}&utm_medium=referral&utm_campaign=docs
+.. _Tidelift Subscription: https://tidelift.com/subscription/pkg/pypi-PROJECT?utm_source=pypi-PROJECT&utm_medium=referral&utm_campaign=docs
+.. _tideliftlogo: https://tidelift.com/subscription/pkg/pypi-PROJECT?utm_source=pypi-PROJECT&utm_medium=referral&utm_campaign=docs
 
 |learn-more|_ |request-a-demo|_
 
 .. |learn-more| image:: https://raw.githubusercontent.com/urllib3/urllib3/master/docs/images/learn-more-button.png
    :width: 49%
    :alt: Learn more about Tidelift Subscription
-.. _learn-more: https://tidelift.com/subscription/pkg/pypi-{{ project }}?utm_source=pypi-{{ project }}&utm_medium=referral&utm_campaign=docs
+.. _learn-more: https://tidelift.com/subscription/pkg/pypi-PROJECT?utm_source=pypi-PROJECT&utm_medium=referral&utm_campaign=docs
 
 .. |request-a-demo| image:: https://raw.githubusercontent.com/urllib3/urllib3/master/docs/images/demo-button.png
    :width: 49%
    :alt: Request a Demo for the Tidelift Subscription
-.. _request-a-demo: https://tidelift.com/subscription/request-a-demo?utm_source=pypi-{{ project }}&utm_medium=referral&utm_campaign=docs
+.. _request-a-demo: https://tidelift.com/subscription/request-a-demo?utm_source=pypi-PROJECT&utm_medium=referral&utm_campaign=docs

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,35 @@
+.. toctree::
+   For Enterprise <https://tidelift.com/subscription/pkg/pypi-{{ project }}?utm_source=pypi-{{ project }}&utm_medium=referral&utm_campaign=docs>
+
+
+For Enterprise
+--------------
+
+.. |tideliftlogo| image:: https://nedbatchelder.com/pix/Tidelift_Logos_RGB_Tidelift_Shorthand_On-White_small.png
+   :width: 75
+   :alt: Tidelift
+
+.. list-table::
+   :widths: 10 100
+
+   * - |tideliftlogo|_
+     - Professional support for {{ project }} is available as part of the `Tidelift
+       Subscription`_.  Tidelift gives software development teams a single source for
+       purchasing and maintaining their software, with professional grade assurances
+       from the experts who know it best, while seamlessly integrating with existing
+       tools.
+
+.. _Tidelift Subscription: https://tidelift.com/subscription/pkg/pypi-{{ project }}?utm_source=pypi-{{ project }}&utm_medium=referral&utm_campaign=docs
+.. _tideliftlogo: https://tidelift.com/subscription/pkg/pypi-{{ project }}?utm_source=pypi-{{ project }}&utm_medium=referral&utm_campaign=docs
+
+|learn-more|_ |request-a-demo|_
+
+.. |learn-more| image:: https://raw.githubusercontent.com/urllib3/urllib3/master/docs/images/learn-more-button.png
+   :width: 49%
+   :alt: Learn more about Tidelift Subscription
+.. _learn-more: https://tidelift.com/subscription/pkg/pypi-{{ project }}?utm_source=pypi-{{ project }}&utm_medium=referral&utm_campaign=docs
+
+.. |request-a-demo| image:: https://raw.githubusercontent.com/urllib3/urllib3/master/docs/images/demo-button.png
+   :width: 49%
+   :alt: Request a Demo for the Tidelift Subscription
+.. _request-a-demo: https://tidelift.com/subscription/request-a-demo?utm_source=pypi-{{ project }}&utm_medium=referral&utm_campaign=docs


### PR DESCRIPTION
Except as part of Table of Contents and borrow For Enterprise content from urllib3. Ref pypa/setuptools#2465.